### PR TITLE
Webpack5 hot-reload fix

### DIFF
--- a/src/Service/AssetManager.php
+++ b/src/Service/AssetManager.php
@@ -46,11 +46,14 @@ class AssetManager
 
         $manifestEntry = $this->getManifestEntry($assetName, sprintf('%s (key %s)', $asset, $assetName));
 
-        if ($type === null) {
-            $type = $this->guessFileType($assetName, $asset, $manifestEntry);
+        if (isset($manifestEntry[$type])) {
+            if (is_array($manifestEntry[$type])) {
+                return reset($manifestEntry[$type]);
+            }
+            return $manifestEntry[$type];
         }
 
-        return isset($manifestEntry[$type]) ? $manifestEntry[$type] : null;
+        return null;
     }
 
     /**


### PR DESCRIPTION
With webpack-5 hot reload you get two files for the same entry-point, so let's use the first one.

![image](https://user-images.githubusercontent.com/7325630/96726600-c848ef80-13ba-11eb-8587-a7003c85cbb7.png)
